### PR TITLE
Add LA Devs to adopters list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -105,6 +105,7 @@ Kiva, https://github.com/kiva
 Kickoff, https://github.com/TryKickoff/kickoff/
 Kong, https://github.com/mashape/kong/
 Kubernetes, https://github.com/kubernetes/kubernetes/
+LA Devs, https://github.com/la-devs/ladevs.org
 Laravel.io, https://github.com/laravelio/portal
 LifxDash, https://github.com/matthutchinson/lifx_dash
 Linode, https://github.com/linode/docs


### PR DESCRIPTION
Adding our community to the list of adopters.

cc: @la-devs/co-founders